### PR TITLE
bugfix/issue-6/download-aarch64

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@
 lazydocker_app: lazydocker
 lazydocker_version: '0.23.3'
 lazydocker_dl_url: https://github.com/jesseduffield/{{ lazydocker_app }}/releases/download/v{{ lazydocker_version }}/{{ lazydocker_app }}_{{ lazydocker_version }}_{{ ansible_system }}_{{ ansible_architecture }}.tar.gz
+lazydocker_dl_url_aarch64: https://github.com/jesseduffield/{{ lazydocker_app }}/releases/download/v{{ lazydocker_version }}/{{ lazydocker_app }}_{{ lazydocker_version }}_{{ ansible_system }}_arm64.tar.gz
 lazydocker_bin_path: /usr/local/bin
 lazydocker_file_owner: root
 lazydocker_file_group: root

--- a/tasks/install_debian_aarch64.yml
+++ b/tasks/install_debian_aarch64.yml
@@ -1,0 +1,13 @@
+---
+# tasks file for lazydocker | Debian/Ubuntu Family and Architecture is ARMv8 (aarch64)
+
+- name: Debian/Ubuntu ARMv8 (Aarch64) Architecture | Download and extracting {{ lazydocker_app }} {{ lazydocker_version }}
+  ansible.builtin.unarchive:
+    src: "{{ lazydocker_dl_url_aarch64 }}"
+    dest: "{{ lazydocker_bin_path }}"
+    extra_opts:
+      - lazydocker
+    remote_src: yes
+    owner: "{{ lazydocker_file_owner }}"
+    group: "{{ lazydocker_file_group }}"
+    mode: "{{ lazydocker_file_mode }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,10 @@
   ansible.builtin.import_tasks: install_debian.yml
   when: ansible_os_family == "Debian"
 
+- name: Import install_debian.yml if OS family is Debian and Architecture is ARMv8 (AArch64)
+  ansible.builtin.import_tasks: install_debian_aarch64.yml
+  when: (ansible_os_family == "Debian") and (ansible_architecture == "aarch64")
+
 - name: Import install_el.yml if OS family is EL
   ansible.builtin.import_tasks: install_el.yml
   when: ansible_os_family == "RedHat"


### PR DESCRIPTION
Hello @darkwizard242 

### Explanation

Similar issue that #6 

The role was not capable to download lazydocker because my ansible_architecture is "aarch64" :

![image](https://github.com/darkwizard242/ansible-role-lazydocker/assets/43102748/54b4fe62-dc8a-4bf6-b4ac-7de7cb93a9d7)

Which resulted in this error :

```
TASK [darkwizard242.lazydocker : Debian/Ubuntu Family | Downloading and extracting lazydocker 0.23.3] ************************************
fatal: [freebox]: FAILED! => {"changed": false, "msg": "Invalid archive '/home/freebox/.ansible/tmp/ansible-tmp-1718472320.7796235-2149-70017382737337/lazydocker_0.23.3_Linux_aarch64czc4tv_b.tar.gz', the file is 0 bytes"}
```

I fixed this issue by adding a new task in `/tasks/main.yml` in order to download the arm64 version of lazydocker. Also added a new task file and a default variable in `defaults/main.yml`.

### Fix

#### tasks/main.yml

```yaml
- name: Import install_debian.yml if OS family is Debian and Architecture is ARMv8 (AArch64)
  ansible.builtin.import_tasks: install_debian_aarch64.yml
  when: (ansible_os_family == "Debian") and (ansible_architecture == "aarch64")
```

#### install_debian_aarch64.yml

```yaml
---
# tasks file for lazydocker | Debian/Ubuntu Family and Architecture is ARMv8 (aarch64)

- name: Debian/Ubuntu ARMv8 (Aarch64) Architecture | Download and extracting {{ lazydocker_app }} {{ lazydocker_version }}
  ansible.builtin.unarchive:
    src: "{{ lazydocker_dl_url_aarch64 }}"
    dest: "{{ lazydocker_bin_path }}"
    extra_opts:
      - lazydocker
    remote_src: yes
    owner: "{{ lazydocker_file_owner }}"
    group: "{{ lazydocker_file_group }}"
    mode: "{{ lazydocker_file_mode }}"
```

#### defaults/main.yml

```yaml
lazydocker_dl_url_aarch64: https://github.com/jesseduffield/{{ lazydocker_app }}/releases/download/v{{ lazydocker_version }}/{{ lazydocker_app }}_{{ lazydocker_version }}_{{ ansible_system }}_arm64.tar.gz
```